### PR TITLE
Run e2e tests with packaged create module as well

### DIFF
--- a/packages/create-dashbling-app/test.sh
+++ b/packages/create-dashbling-app/test.sh
@@ -1,17 +1,30 @@
 #!/usr/bin/env bash
 set -e ; [[ $TRACE ]] && set -x
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t dashbling-tests)
 
 cleanup() {
   status=$?
   rm -rf "$TMP_DIR"
+  rm -rf "$packagePath"
   exit $status
+}
+
+packageVersion() {
+  node -e "console.log(require('./package.json').version)"
+}
+
+packagePath() {
+  echo "$SCRIPTPATH/dashbling-create-dashboard-$(packageVersion).tgz"
 }
 
 trap "cleanup" INT TERM EXIT
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-"$SCRIPTPATH/create-dashboard.js" "$TMP_DIR"
+npm pack
+packagePath=$(packagePath)
 
 cd "$TMP_DIR"
-./node_modules/.bin/dashbling compile
+yarn add "file:$packagePath"
+
+./node_modules/.bin/create-dashboard .
+yarn build


### PR DESCRIPTION
All modules were already used packaged in e2e tests, except for the create module.