### PR TITLE
Allow Hapi server to be customized during initialization

### DIFF
--- a/example/dashbling.config.js
+++ b/example/dashbling.config.js
@@ -20,6 +20,22 @@ module.exports = {
     // start custom code that sends events here,
     // for example listen to streams etc.
   },
+  configureServer: hapiServer => {
+    // Configure the Hapi server here.
+    // See https://hapijs.com/api/17.1.1 docs for details.
+    // This is only needed for more advanced use cases.
+    hapiServer.route({
+      method: "GET",
+      path: "/ping",
+      handler: (_request, _h) => {
+        return "pong";
+      }
+    });
+
+    // Be sure to return a Promise, so the initialization process
+    // waits for this configuration to be completed.
+    return Promise.resolve();
+  },
   eventHistory: createFileHistory(eventHistoryPath),
   forceHttps: false,
   jobs: [

--- a/example/dashbling.config.js
+++ b/example/dashbling.config.js
@@ -20,7 +20,7 @@ module.exports = {
     // start custom code that sends events here,
     // for example listen to streams etc.
   },
-  configureServer: hapiServer => {
+  configureServer: async hapiServer => {
     // Configure the Hapi server here.
     // See https://hapijs.com/api/17.1.1 docs for details.
     // This is only needed for more advanced use cases.
@@ -31,10 +31,6 @@ module.exports = {
         return "pong";
       }
     });
-
-    // Be sure to return a Promise, so the initialization process
-    // waits for this configuration to be completed.
-    return Promise.resolve();
   },
   eventHistory: createFileHistory(eventHistoryPath),
   forceHttps: false,

--- a/packages/core/src/lib/clientConfig.ts
+++ b/packages/core/src/lib/clientConfig.ts
@@ -29,6 +29,7 @@ export interface ClientConfig {
   readonly projectPath: string;
   readonly jobs: JobConfig[];
   readonly onStart: (sendEvent: SendEvent) => void;
+  readonly configureServer: (server: any) => Promise<void>;
   readonly webpackConfig: (defaultConfig: any) => any;
   readonly eventHistory: Promise<EventHistory>;
 
@@ -42,6 +43,7 @@ const DEFAULTS: { [key: string]: any } = {
   port: 3000,
   forceHttps: false,
   onStart: () => {},
+  configureServer: () => Promise.resolve(),
   webpackConfig: (config: any) => config,
   authToken: () => {
     const token = generateAuthToken();
@@ -168,6 +170,10 @@ export const parse = (
     throw error("onStart", "a function", input.onStart);
   }
 
+  if (input.configureServer != null && !isFunction(input.configureServer)) {
+    throw error("configureServer", "a function", input.configureServer);
+  }
+
   if (input.webpackConfig != null && !isFunction(input.webpackConfig)) {
     throw error("webpackConfig", "a function", input.webpackConfig);
   }
@@ -185,6 +191,7 @@ export const parse = (
   return {
     projectPath: projectPath,
     onStart: input.onStart || DEFAULTS.onStart,
+    configureServer: input.configureServer || DEFAULTS.configureServer,
     webpackConfig: input.webpackConfig || DEFAULTS.webpackConfig,
     jobs: input.jobs,
     forceHttps: loadConfigOption("forceHttps", tryParseBool),

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -62,7 +62,9 @@ export const start = async (projectPath: string, eventBus?: EventBus) => {
 
   const sendEvent = eventBus.publish.bind(eventBus);
   jobs.start(clientConfig, sendEvent);
+
   clientConfig.onStart(sendEvent);
+  await clientConfig.configureServer(server);
 
   await server.initialize();
   await server.start();

--- a/packages/core/test/clientConfig.test.ts
+++ b/packages/core/test/clientConfig.test.ts
@@ -44,6 +44,16 @@ test("validates onStart", () => {
   expect(error).toMatch(/Invalid 'onStart'/);
 });
 
+test("validates configureServer", () => {
+  const config = {
+    ...basicValidConfig,
+    configureServer: "wrong type"
+  };
+
+  const error = parseAndExtractError(config);
+  expect(error).toMatch(/Invalid 'configureServer'/);
+});
+
 test("throws if passed invalid cron expression", () => {
   const raw = {
     ...basicValidConfig,

--- a/packages/core/test/integration/server.integration.test.ts
+++ b/packages/core/test/integration/server.integration.test.ts
@@ -181,6 +181,22 @@ test("calls config.onStart", async () => {
   expect(publishSpy).toHaveBeenCalledWith("myEvent", {});
 });
 
+test("calls config.configureServer", async () => {
+  const eventBus = await createEventBus();
+
+  dashblingConfig.configureServer = jest.fn((server: any) => {
+    expect(server.route).not.toBeUndefined();
+    return Promise.resolve();
+  });
+
+  serverInstance = await server.start(
+    path.join(__dirname, "..", "fixture"),
+    eventBus
+  );
+
+  expect(dashblingConfig.configureServer).toHaveBeenCalled();
+});
+
 describe("forcing https", () => {
   test("supports forcing https", async () => {
     dashblingConfig.forceHttps = true;


### PR DESCRIPTION
With this, the Hapi server can be customized during initialization.
Use cases are outlined in https://github.com/pascalw/dashbling/issues/20.