### PR TITLE
Add EventReducer concept to modify event data as it comes in

### DIFF
--- a/docs/event-reducer.md
+++ b/docs/event-reducer.md
@@ -1,0 +1,58 @@
+# Using an Event Reducer
+
+By default, Dashbling keeps track of the last event data per event type. For advanced use cases you can customize this behaviour by providing an `EventReducer`.
+
+An `EventReducer` looks like this:
+
+```typescript
+interface Reducer {
+  (eventId: string, previousState: any | null, eventData: any): any;
+}
+```
+
+Event data that flows into Dashbling, either from jobs or from data pushed in via the REST API, is passed to the reducer allow it to modify the data before it gets stored in the history and pushed to clients.
+
+An `EventReducer` is a function that takes an `eventId`, the previous state that was stored for this event (or `null` if it's the first time an event is triggered) and the `eventData` that's coming in. The default implementation simply returns the new data like this:
+
+```javascript
+const defaultReducer = (_eventId, _previousState, eventData) => {
+  return eventData;
+};
+```
+
+You can create a custom reducer in case you want to override this behaviour.
+
+For example say you have events with the following data:
+
+```javascript
+const event = {
+  name: "Alice"
+};
+```
+
+And you want to aggregate all events, you might define a reducer like this:
+
+```javascript
+eventReducer: (id, eventState, event) => {
+    switch (id) {
+      case "hello":
+        if (eventState.names) {
+          // existing state, append the incoming name to the list of names.
+          return { names: [...eventState.names, event.name] };
+        } else {
+          // existing state doesn't match our expectation, create a new state.
+          return { names: [event.name] };
+        }
+      default:
+        return event;
+    }
+  }
+```
+
+This means that the following data will be stored for the `hello` event:
+
+```json
+{
+    "names": ["Alice", "Bob", "John"]
+}
+```

--- a/packages/core/src/lib/clientConfig.ts
+++ b/packages/core/src/lib/clientConfig.ts
@@ -4,6 +4,7 @@ import logger from "./logger";
 import { generate as generateAuthToken } from "./authToken";
 import { SendEvent } from "./sendEvent";
 import { EventHistory } from "./EventHistory";
+import { Reducer, defaultReducer } from "./eventBus";
 
 interface ConfigSource {
   get: (option: string) => any;
@@ -32,6 +33,7 @@ export interface ClientConfig {
   readonly configureServer: (server: any) => Promise<void>;
   readonly webpackConfig: (defaultConfig: any) => any;
   readonly eventHistory: Promise<EventHistory>;
+  readonly eventReducer: Reducer;
 
   readonly forceHttps: boolean;
   readonly port: number;
@@ -54,7 +56,8 @@ const DEFAULTS: { [key: string]: any } = {
     );
 
     return token;
-  }
+  },
+  eventReducer: defaultReducer
 };
 
 const error = (name: string, expectation: string, actualValue: any): Error => {
@@ -179,7 +182,11 @@ export const parse = (
   }
 
   if (!(input.eventHistory instanceof Promise)) {
-    throw error("eventHistory", "`a Promise<EventHistory>", input.eventHistory);
+    throw error("eventHistory", "a Promise<EventHistory>", input.eventHistory);
+  }
+
+  if (input.eventReducer != null && !isFunction(input.eventReducer)) {
+    throw error("eventReducer", "a function", input.eventReducer);
   }
 
   const loadConfigOption = getConfigOption([
@@ -193,6 +200,7 @@ export const parse = (
     onStart: input.onStart || DEFAULTS.onStart,
     configureServer: input.configureServer || DEFAULTS.configureServer,
     webpackConfig: input.webpackConfig || DEFAULTS.webpackConfig,
+    eventReducer: input.eventReducer || DEFAULTS.eventReducer,
     jobs: input.jobs,
     forceHttps: loadConfigOption("forceHttps", tryParseBool),
     port: loadConfigOption("port", tryParseNumber),

--- a/packages/core/src/lib/eventBus.ts
+++ b/packages/core/src/lib/eventBus.ts
@@ -6,12 +6,12 @@ export interface Subscriber {
 }
 
 export interface Reducer {
-  (eventId: string, previousState: any | null, eventData: any): any;
+  (eventId: string, previousState: any | undefined, eventData: any): any;
 }
 
 export const defaultReducer: Reducer = (
   _id: string,
-  _oldState: any | null,
+  _previousState: any | undefined,
   event: any
 ): any => {
   return event;
@@ -43,7 +43,7 @@ export class EventBus {
 
   async publish(id: string, data: any) {
     const previousState = await this.history.get(id);
-    const previousData = previousState == null ? null : previousState.data;
+    const previousData = previousState ? previousState.data : undefined;
 
     const reducedData = this.reducer(id, previousData, data);
     const event: Event = {

--- a/packages/core/src/lib/eventBus.ts
+++ b/packages/core/src/lib/eventBus.ts
@@ -5,13 +5,31 @@ export interface Subscriber {
   (event: Event): void;
 }
 
+export interface Reducer {
+  (eventId: string, previousState: any | null, eventData: any): any;
+}
+
+export const defaultReducer: Reducer = (
+  _id: string,
+  _oldState: any | null,
+  event: any
+): any => {
+  return event;
+};
+
 export class EventBus {
   private subscribers: Subscriber[];
   private history: EventHistory;
+  private reducer: Reducer;
 
-  constructor(history: EventHistory) {
+  static withDefaultReducer(history: EventHistory) {
+    return new EventBus(history, defaultReducer);
+  }
+
+  constructor(history: EventHistory, reducer: Reducer) {
     this.subscribers = [];
     this.history = history;
+    this.reducer = reducer;
   }
 
   subscribe(subscriber: Subscriber) {
@@ -24,7 +42,16 @@ export class EventBus {
   }
 
   async publish(id: string, data: any) {
-    const event: Event = { id, data, updatedAt: new Date(Date.now()) };
+    const previousState = await this.history.get(id);
+    const previousData = previousState == null ? null : previousState.data;
+
+    const reducedData = this.reducer(id, previousData, data);
+    const event: Event = {
+      id,
+      data: reducedData,
+      updatedAt: new Date(Date.now())
+    };
+
     this.subscribers.forEach(subscriber => subscriber(event));
     return this.history.put(id, event);
   }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -48,7 +48,7 @@ export const start = async (projectPath: string, eventBus?: EventBus) => {
   const environment = process.env.NODE_ENV || "production";
 
   const history = await createEventHistory(clientConfig);
-  eventBus = eventBus || new EventBus(history);
+  eventBus = eventBus || new EventBus(history, clientConfig.eventReducer);
 
   const server = new Hapi.Server({
     port: clientConfig.port

--- a/packages/core/test/clientConfig.test.ts
+++ b/packages/core/test/clientConfig.test.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import { ClientConfig, parse, load } from "../src/lib/clientConfig";
+import { defaultReducer } from "../src/lib/eventBus";
 
 const projectPath = "/fake";
 const basicValidConfig = {
@@ -156,6 +157,23 @@ describe("webpackConfig", () => {
 
     const error = parseAndExtractError(rawConfig);
     expect(error).toMatch(/webpackConfig/);
+  });
+});
+
+describe("eventReducer", () => {
+  test("defaults to defaultReducer", () => {
+    const config: ClientConfig = parse(basicValidConfig, projectPath);
+    expect(config.eventReducer).toEqual(defaultReducer);
+  });
+
+  test("validates is a function", () => {
+    const rawConfig = {
+      ...basicValidConfig,
+      eventReducer: 123
+    };
+
+    const error = parseAndExtractError(rawConfig);
+    expect(error).toMatch(/eventReducer/);
   });
 });
 

--- a/packages/core/test/eventBus.test.ts
+++ b/packages/core/test/eventBus.test.ts
@@ -36,23 +36,40 @@ test("sends events to all subscribers", async () => {
   });
 });
 
-test("passes the event data to the reducer", async () => {
-  const subscriber1 = jest.fn();
-  const history = await createHistory();
+describe("event reducing", () => {
+  test("passes the event data to the reducer", async () => {
+    const subscriber1 = jest.fn();
+    const history = await createHistory();
 
-  const reducer = (_id: string, _previousState: any, eventData: any) => {
-    return { wrapped: eventData };
-  };
+    const reducer = (_id: string, _previousState: any, eventData: any) => {
+      return { wrapped: eventData };
+    };
 
-  const eventBus = new EventBus(history, reducer);
+    const eventBus = new EventBus(history, reducer);
 
-  eventBus.subscribe(subscriber1);
-  await eventBus.publish("myEvent", { arg: "1" });
+    eventBus.subscribe(subscriber1);
+    await eventBus.publish("myEvent", { arg: "1" });
 
-  expect(subscriber1).toBeCalledWith({
-    id: "myEvent",
-    data: { wrapped: { arg: "1" } },
-    updatedAt: NOW
+    expect(subscriber1).toBeCalledWith({
+      id: "myEvent",
+      data: { wrapped: { arg: "1" } },
+      updatedAt: NOW
+    });
+  });
+
+  test("previousState is undefined if no previousState was stored", async () => {
+    const previousStateSpy = jest.fn();
+    const history = await createHistory();
+
+    const reducer = (_id: string, previousState: any, eventData: any) => {
+      previousStateSpy(previousState);
+      return eventData;
+    };
+
+    const eventBus = new EventBus(history, reducer);
+    await eventBus.publish("myEvent", { arg: "1" });
+
+    expect(previousStateSpy).toBeCalledWith(undefined);
   });
 });
 

--- a/packages/core/test/integration/server.integration.test.ts
+++ b/packages/core/test/integration/server.integration.test.ts
@@ -26,7 +26,7 @@ const extractEvents = (onEvent: ((event: any) => void)) => (
 
 const createEventBus = async () => {
   const history = await createHistory();
-  return new EventBus(history);
+  return EventBus.withDefaultReducer(history);
 };
 
 const NOW = new Date();


### PR DESCRIPTION
This feature mainly helps support use cases where data is pushed into Dashbling and you want to aggregate that data; for example keeping track of the full history of data that is pushed for a given `eventId`.

/cc @luc-tielen @leonderijke