### PR TITLE
Prevent Widget style leaking outside the module scope

### DIFF
--- a/packages/client/Widget.js
+++ b/packages/client/Widget.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "./Widget.scss";
 
+const classes = classNames => classNames.filter(Boolean).join(" ");
+
 const bgImage = image => {
   return (
     <div
@@ -12,9 +14,7 @@ const bgImage = image => {
 };
 
 export const Widget = (props, context) => {
-  const className = `${styles.widget} ${context.layout.widget}${
-    props.className ? " " + props.className : ""
-  }`;
+  const className =  classes([styles.widget, context.layout.widget, props.className]);
 
   let children = props.title ? (
     <React.Fragment>
@@ -56,8 +56,10 @@ export const LargeLabel = props => {
 };
 
 export const Label = (props, className) => {
+  const labelClassName = classes([styles.label, className]);
+
   return (
-    <span className={className} {...props}>
+    <span className={labelClassName} {...props}>
       {props.children}
     </span>
   );

--- a/packages/client/Widget.js
+++ b/packages/client/Widget.js
@@ -14,7 +14,11 @@ const bgImage = image => {
 };
 
 export const Widget = (props, context) => {
-  const className =  classes([styles.widget, context.layout.widget, props.className]);
+  const className = classes([
+    styles.widget,
+    context.layout.widget,
+    props.className
+  ]);
 
   let children = props.title ? (
     <React.Fragment>

--- a/packages/client/Widget.scss
+++ b/packages/client/Widget.scss
@@ -30,6 +30,12 @@
   max-height: 100%;
 }
 
+.label {
+  display: block;
+  width: 100%;
+  text-align: center;
+}
+
 .labelLarge {
   font-size: 4em;
 }
@@ -40,12 +46,6 @@
 
 .labelSmall {
   font-size: 1.5em;
-}
-
-span {
-  display: block;
-  width: 100%;
-  text-align: center;
 }
 
 .link {


### PR DESCRIPTION
The element selector in the Widget styles would leak outside the CSS module scope. By turning this into a class selector we can contain it in the module.